### PR TITLE
doc: add cert store invalid cert tsg

### DIFF
--- a/docs/ratify-configuration.mdx
+++ b/docs/ratify-configuration.mdx
@@ -41,3 +41,8 @@ Sample command to remove a verifier:
 ```bash
 kubectl delete verifiers.config.ratify.deislabs.io/verifier-notary 
 ```
+
+### Limitations
+Currently Ratify only supports single namespace, Ratify cannot distinguish CRs with the same metadata name from different namespaces.
+To ensure predictable results, please install all CRs in a single namespace. This limitation is being tracked by issue [1061](https://github.com/deislabs/ratify/issues/1061)
+

--- a/docs/reference/crds/certificate-stores.md
+++ b/docs/reference/crds/certificate-stores.md
@@ -107,8 +107,6 @@ The main use case of certificate store is for notation verifier in Ratify, so us
 
 In brief, users must provide CA certificates or self-signed signing certificates, which means leaf certificates are not allowed to be used. Whatever certificates are provided, Ratify would keep only CA certificates and self-signed certificates. Therefore, if only leaf certificates are provided, Ratify would fail the verification directly since there are no valid certificates.
 
-For `AzureKeyVault Certificate Provider`, users must use the self-signed certificates due to some limitations on the SDK API. If users want to configure a certificate chain from root to leaf, it's recommended to use the `Inline Certificate Provider` instead.
-
 # CRD Resource Create/Update 
 During the CRD creating/updating process, some matters require attention. The CRD operation could be successful even though some invalid values or typos are provided. Examples:
 

--- a/docs/troubleshoot/certstore/cert-invalid-tsg.md
+++ b/docs/troubleshoot/certstore/cert-invalid-tsg.md
@@ -1,0 +1,21 @@
+## Troubleshoot Certificate Store Errors
+
+Please use ```kubectl get``` or ```kubectl describe``` command to retrieve the error.
+```bash
+kubectl get certificatestores.config.ratify.deislabs.io
+```
+###  CERT_INVALID
+This error is returned when Ratify fails to parse certificate fetched from Certifiate Store.
+
+#### Scenario 1
+Brieferror:       failed to get certificates fro...   
+Error:            failed to get certificates from secret bundle:  
+Original Error: (**pkcs12: expected exactly two items in the authenticated safe**),  
+Error: cert invalid,  
+Code: **CERT_INVALID**,  
+Plugin Name: azurekeyvault, Component Type: certProvider,  
+Detail: **azure keyvault certificate provider: failed to convert PKCS12 Value to PEM**. Certificate default, version b81be595959f46fbb1c704018d29aca8  
+Issuccess:        false  
+
+##### Cause and Solution
+PKCS12 format certs in Key Vault with nonexportable private keys causes a parsing failure because Go is hardcoded to expect a private key. We recommend switching to a PEM certs. 


### PR DESCRIPTION
this PR contains changes below:

- Add limitation about only supporting single namespace
- we now support getting entire cert chain ,remove earlier note about only supporting self signed cert
- Spired by AKS tsg (https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/error-code-requestdisallowedbypolicy) , I ve added sample for cert-invalid error.
We could add a TSG md for each error with sample error msg and suggested solution