### PR TITLE
doc: update quickstart to add optional dev build install

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -18,6 +18,8 @@ Prerequisites:
 helmfile sync -f git::https://github.com/deislabs/ratify.git@helmfile.yaml
 ```
 
+> **NOTE** To use the latest development version of Ratify instead, refer to this [document](https://github.com/deislabs/ratify/blob/main/CONTRIBUTING.md#deploy-using-dev-helmfile)
+
 ### Step 2: See Ratify in action
 
 Once the installation is completed, you can test the deployment of an image that is signed using Notation solution.


### PR DESCRIPTION
- updates quickstart to add dev build install option as described in CONTRIBUTING.md in the main Ratify repo