### PR TITLE
fix: update vuln constraint template to point to updated version

### DIFF
--- a/docs/external plugins/Verifier/vulnerabilityreport.md
+++ b/docs/external plugins/Verifier/vulnerabilityreport.md
@@ -53,7 +53,7 @@ helm install ratify \
 Next, install the vulnerability report constraint template and constraint. The Constraint Template defines the policy "all container images used in K8s resources have at least one valid most recent vulnerability report attached to the image and the report has a valid Notary Project signature"
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/deislabs/ratify/v1.1.0/library/vulnerability-report-validation/template.yaml
+kubectl apply -f https://raw.githubusercontent.com/deislabs/ratify/23b143d07a53fd61557703c9836e486353959530/library/vulnerability-report-validation/template.yaml
 
 kubectl apply -f https://raw.githubusercontent.com/deislabs/ratify/v1.1.0/library/vulnerability-report-validation/samples/constraint.yaml
 ```
@@ -238,7 +238,7 @@ helm install ratify \
 Next, install the vulnerability report constraint template and constraint. The Constraint Template defines the policy "all container images used in K8s resources have at least one valid most recent vulnerability report attached to the image and the report has a valid Notary Project signature"
 
 ```shell
-curl https://raw.githubusercontent.com/deislabs/ratify/v1.1.0/library/vulnerability-report-validation/template.yaml | sed 's/require_signature := false/require_signature := true/' | kubectl apply -f -
+curl https://raw.githubusercontent.com/deislabs/ratify/23b143d07a53fd61557703c9836e486353959530/library/vulnerability-report-validation/template.yaml | sed 's/require_signature := false/require_signature := true/' | kubectl apply -f -
 
 kubectl apply -f https://raw.githubusercontent.com/deislabs/ratify/v1.1.0/library/vulnerability-report-validation/samples/constraint.yaml
 ```

--- a/versioned_docs/version-1.1/external plugins/Verifier/vulnerabilityreport.md
+++ b/versioned_docs/version-1.1/external plugins/Verifier/vulnerabilityreport.md
@@ -53,7 +53,7 @@ helm install ratify \
 Next, install the vulnerability report constraint template and constraint. The Constraint Template defines the policy "all container images used in K8s resources have at least one valid most recent vulnerability report attached to the image and the report has a valid Notary Project signature"
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/deislabs/ratify/v1.1.0/library/vulnerability-report-validation/template.yaml
+kubectl apply -f https://raw.githubusercontent.com/deislabs/ratify/23b143d07a53fd61557703c9836e486353959530/library/vulnerability-report-validation/template.yaml
 
 kubectl apply -f https://raw.githubusercontent.com/deislabs/ratify/v1.1.0/library/vulnerability-report-validation/samples/constraint.yaml
 ```
@@ -238,7 +238,7 @@ helm install ratify \
 Next, install the vulnerability report constraint template and constraint. The Constraint Template defines the policy "all container images used in K8s resources have at least one valid most recent vulnerability report attached to the image and the report has a valid Notary Project signature"
 
 ```shell
-curl https://raw.githubusercontent.com/deislabs/ratify/v1.1.0/library/vulnerability-report-validation/template.yaml | sed 's/require_signature := false/require_signature := true/' | kubectl apply -f -
+curl https://raw.githubusercontent.com/deislabs/ratify/23b143d07a53fd61557703c9836e486353959530/library/vulnerability-report-validation/template.yaml | sed 's/require_signature := false/require_signature := true/' | kubectl apply -f -
 
 kubectl apply -f https://raw.githubusercontent.com/deislabs/ratify/v1.1.0/library/vulnerability-report-validation/samples/constraint.yaml
 ```


### PR DESCRIPTION
The vulnerability template from v1.1.0 is faulty and has now been fixed on main branch of the repo. This PR updates the unreleased docs and the v1.1.0 version to point to the fixed template.